### PR TITLE
Add plyr to parallel packages for mainFunction

### DIFF
--- a/Analysis_Hdf5_tracking_CD_v3_4.Rmd
+++ b/Analysis_Hdf5_tracking_CD_v3_4.Rmd
@@ -181,7 +181,7 @@ if(length(hdf5FileNameL) > 1) {
 registerDoParallel(min(numberCores, length(hdf5FileNameL)))
 
 outputList<- foreach( h5loop = seq_along(hdf5FileNameL ),
-                      .packages = c("rhdf5", "stringr", "data.table")) %dopar% 
+                      .packages = c("rhdf5", "stringr", "data.table", "plyr")) %dopar%
   {
 
      mainFunction( h5loop=h5loop,


### PR DESCRIPTION
If "duplicate locationID - plateID keys, check layout file" there is a call to
count(), which is from plyr, otherwise mainFunction fails with "can't find
function "count"".